### PR TITLE
New start script / Tic Tac Toe bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "svelte-kit dev",
     "dev:open": "svelte-kit dev -- --open",
+    "dev:host": "svelte-kit dev --host",
     "build": "svelte-kit build",
     "package": "svelte-kit package",
     "preview": "svelte-kit preview",

--- a/src/lib/playground/tic-tac-toe/utils/coords.ts
+++ b/src/lib/playground/tic-tac-toe/utils/coords.ts
@@ -43,7 +43,7 @@ export const checks : GetCoordChecksLists = [
     ],
     // Checks for Coord 4
     [
-        getAdjacentRight,
+        getAdjacentLeftRight,
         getAdjacentUpDown,
         getDiagonalUpLeftDownRight,
         getDiagonalUpRightDownLeft


### PR DESCRIPTION
- Added script `dev:host` to start the dev server with the `--host` flag to enable a network host to make the site accessible to other devices on the same network.

- Fixed win condition when ending on the center tile.